### PR TITLE
JSON.parse wrapping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,11 @@ Odoo.prototype.connect = function (cb) {
     });
 
     res.on('end', function () {
-      response = JSON.parse(response);
+      try {
+        response = JSON.parse(response);
+      } catch (err) {
+        return cb(err, null);
+      }
 
       if (response.error) {
         return cb(response.error, null);


### PR DESCRIPTION
wrap vulnerable `JSON.parse` into `try {} catch {}` construction

To handle `SyntaxError` exceprions instead of throwing it
